### PR TITLE
Update to new Sonatype host

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,14 @@ allprojects {
         google()
         mavenCentral()
     }
+}
 
+allprojects {
+    plugins.withId("com.vanniktech.maven.publish") {
+        mavenPublish {
+            sonatypeHost = "S01"
+        }
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
Following steps in https://github.com/vanniktech/gradle-maven-publish-plugin#where-to-upload-to for pointing to the new host.