### PR TITLE
Updates project references to use task inputs so tasks are compatible with Configuration Cache.

### DIFF
--- a/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/ClearFocusTask.kt
+++ b/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/ClearFocusTask.kt
@@ -1,7 +1,8 @@
 package com.dropbox.focus
 
+import java.io.File
 import org.gradle.api.DefaultTask
-import org.gradle.api.provider.Property
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -11,12 +12,13 @@ import org.gradle.api.tasks.TaskAction
 public abstract class ClearFocusTask : DefaultTask() {
 
   @get:Input
-  public abstract val focusFileName: Property<String>
+  public abstract val focusFile: RegularFileProperty
 
   @TaskAction
   public fun clearFocus() {
-    val focusFile = project.rootDir.resolve(focusFileName.get())
-    focusFile.delete()
+    if (focusFile.isPresent) {
+      focusFile.asFile.get().delete()
+    }
   }
 
   public companion object {
@@ -24,7 +26,7 @@ public abstract class ClearFocusTask : DefaultTask() {
       focusFileName: Provider<String>
     ): ClearFocusTask.() -> Unit = {
       group = FOCUS_TASK_GROUP
-      this.focusFileName.set(focusFileName)
+      this.focusFile.set(project.rootProject.layout.file(focusFileName.map { File(it) }))
     }
   }
 }

--- a/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/FocusTask.kt
+++ b/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/FocusTask.kt
@@ -1,16 +1,21 @@
 package com.dropbox.focus
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 public abstract class FocusTask : DefaultTask() {
+
+  @get:InputDirectory
+  public abstract val rootProjectDir: DirectoryProperty
 
   @get:InputFile
   public abstract val moduleSettingsFile: RegularFileProperty
@@ -24,7 +29,7 @@ public abstract class FocusTask : DefaultTask() {
   @TaskAction
   public fun focus() {
     focusFile.get().asFile.writer().use { writer ->
-      writer.write(moduleSettingsFile.get().asFile.toRelativeString(project.rootDir))
+      writer.write(moduleSettingsFile.get().asFile.toRelativeString(rootProjectDir.get().asFile))
     }
   }
 
@@ -35,6 +40,7 @@ public abstract class FocusTask : DefaultTask() {
     ): FocusTask.() -> Unit = {
       group = FOCUS_TASK_GROUP
 
+      this.rootProjectDir.set(project.rootProject.layout.projectDirectory)
       this.moduleSettingsFile.set(moduleSettingsFile)
       this.rootFocusFileName.set(rootFocusFileName)
       focusFile.set(project.rootProject.layout.projectDirectory.file(rootFocusFileName))


### PR DESCRIPTION
Fixes the [issue](https://twitter.com/droidxav/status/1508985697889181698?s=20&t=mStkQLYAe2PBS3cwOQJz7Q) identified by @ducrohet that caused some tasks to break the configuration cache.