### PR TITLE
Fixing typo in settings.gradle section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Apply the plugin in your `settings.gradle` file.
 
 ```groovy
 // settings.gradle(.kts)
-pluginsManagement {
+pluginManagement {
   repositories {
     mavenCentral()
     gradlePluginPortal()


### PR DESCRIPTION
Small typo in the settings.gradle section of the README.md file.