### PR TITLE
Fix KGP dependency configuration

### DIFF
--- a/focus-gradle-plugin/build.gradle.kts
+++ b/focus-gradle-plugin/build.gradle.kts
@@ -67,9 +67,11 @@ mavenPublish {
 dependencies {
   compileOnly(gradleApi())
   implementation(platform(libs.kotlin.bom))
-  implementation(libs.kotlin.plugin)
+  // Don't impose our version of KGP on consumers
+  compileOnly(libs.kotlin.plugin)
 
   testImplementation(gradleTestKit())
+  testImplementation(libs.kotlin.plugin)
   testImplementation(libs.junit)
   testImplementation(libs.truth)
 }

--- a/focus-gradle-plugin/build.gradle.kts
+++ b/focus-gradle-plugin/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
   compileOnly(libs.kotlin.plugin)
 
   testImplementation(gradleTestKit())
+  testImplementation(platform(libs.kotlin.bom))
   testImplementation(libs.kotlin.plugin)
   testImplementation(libs.junit)
   testImplementation(libs.truth)

--- a/focus-gradle-plugin/src/test/projects/configuration-cache-compatible/build.gradle
+++ b/focus-gradle-plugin/src/test/projects/configuration-cache-compatible/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-  id 'org.jetbrains.kotlin.jvm'
+  id 'org.jetbrains.kotlin.jvm' version '1.6.10'
 }

--- a/focus-gradle-plugin/src/test/projects/configuration-cache-compatible/build.gradle
+++ b/focus-gradle-plugin/src/test/projects/configuration-cache-compatible/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-  id 'org.jetbrains.kotlin.jvm' version '1.6.10'
+  alias(libs.plugins.kotlin.jvm)
 }

--- a/focus-gradle-plugin/src/test/projects/configuration-cache-compatible/settings.gradle
+++ b/focus-gradle-plugin/src/test/projects/configuration-cache-compatible/settings.gradle
@@ -1,3 +1,11 @@
 plugins {
   id 'com.dropbox.focus'
 }
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../../../../../gradle/libs.versions.toml"))
+    }
+  }
+}

--- a/focus-gradle-plugin/src/test/projects/missing-settings-all/build.gradle
+++ b/focus-gradle-plugin/src/test/projects/missing-settings-all/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-  id 'org.jetbrains.kotlin.jvm'
+  alias(libs.plugins.kotlin.jvm)
 }

--- a/focus-gradle-plugin/src/test/projects/missing-settings-all/settings.gradle
+++ b/focus-gradle-plugin/src/test/projects/missing-settings-all/settings.gradle
@@ -1,3 +1,11 @@
 plugins {
   id 'com.dropbox.focus'
 }
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../../../../../gradle/libs.versions.toml"))
+    }
+  }
+}

--- a/focus-gradle-plugin/src/test/projects/single-quote-path/build.gradle
+++ b/focus-gradle-plugin/src/test/projects/single-quote-path/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-  id 'org.jetbrains.kotlin.jvm'
+  id 'org.jetbrains.kotlin.jvm' version '1.6.10'
 }

--- a/focus-gradle-plugin/src/test/projects/single-quote-path/build.gradle
+++ b/focus-gradle-plugin/src/test/projects/single-quote-path/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-  id 'org.jetbrains.kotlin.jvm' version '1.6.10'
+  alias(libs.plugins.kotlin.jvm)
 }

--- a/focus-gradle-plugin/src/test/projects/single-quote-path/settings.gradle
+++ b/focus-gradle-plugin/src/test/projects/single-quote-path/settings.gradle
@@ -1,3 +1,11 @@
 plugins {
   id 'com.dropbox.focus'
 }
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../../../../../gradle/libs.versions.toml"))
+    }
+  }
+}


### PR DESCRIPTION
This should be `compileOnly` so that this doesn't impose the plugin's KGP dependency version on consumers and allow them to bring their own