### PR TITLE
Support Windows file path separator

### DIFF
--- a/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/CreateFocusSettingsTask.kt
+++ b/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/CreateFocusSettingsTask.kt
@@ -37,12 +37,13 @@ public abstract class CreateFocusSettingsTask : DefaultTask() {
       writer.appendLine()
 
       // Add overrides for projects with a root that's different from the gradle path
-      val literalQuoteChar = "'"
       dependencies
         .forEach { dep ->
           val gradleProjectPath = dep.path.substring(1).replace(":", "/")
           if (project.rootDir.resolve(gradleProjectPath) != dep.projectDir) {
-            writer.appendLine("project(\"${dep.path}\").projectDir = new File($literalQuoteChar${dep.projectDir}$literalQuoteChar)")
+            val gradleProjectDir = dep.projectDir.path.replace("\\", "\\\\")
+            // language=groovy
+            writer.appendLine("""project("${dep.path}").projectDir = new File('$gradleProjectDir')""")
           }
         }
     }

--- a/focus-gradle-plugin/src/test/kotlin/com/dropbox/focus/FocusPluginTest.kt
+++ b/focus-gradle-plugin/src/test/kotlin/com/dropbox/focus/FocusPluginTest.kt
@@ -46,8 +46,9 @@ class FocusPluginTest {
       .runFixture(fixtureRoot) { build() }
 
     val focusFileContent = File("src/test/projects/single-quote-path/build/notnowhere/build/focus.settings.gradle").readText()
-    assertThat(focusFileContent)
-      .containsMatch("""project\(\":module\"\).projectDir = new File\(\'.*/src/test/projects/single-quote-path/build/notnowhere\'\)""")
+    val absoluteFilePath = fixtureRoot.resolve("build/notnowhere").absolutePath.replace("\\", "\\\\")
+    // language=groovy
+    assertThat(focusFileContent).contains("""project(":module").projectDir = new File('$absoluteFilePath')""")
   }
 
   private fun GradleRunner.runFixture(

--- a/focus-gradle-plugin/src/test/projects/single-quote-path/settings-all.gradle
+++ b/focus-gradle-plugin/src/test/projects/single-quote-path/settings-all.gradle
@@ -1,3 +1,3 @@
 include(":module")
 
-project(":module").projectDir = new File("${rootProject.projectDir}\\build\\notnowhere")
+project(":module").projectDir = new File(rootDir, "build/notnowhere")


### PR DESCRIPTION
And update corresponding `singleQuotePath` test.

Closes #34