### PR TITLE
Fixes Issue 33 - 'RegularFileProperty' annotated with @Input cannot determine how to interpret the file

### DIFF
--- a/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/ClearFocusTask.kt
+++ b/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/ClearFocusTask.kt
@@ -6,12 +6,16 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 public abstract class ClearFocusTask : DefaultTask() {
 
-  @get:Input
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  @get:InputFile
   public abstract val focusFile: RegularFileProperty
 
   @TaskAction


### PR DESCRIPTION
#### Description
- Fixes https://github.com/dropbox/focus/issues/33

```terminal 
* What went wrong:
A problem was found with the configuration of task ':clearFocus' (type 'ClearFocusTask').
  - Type 'com.dropbox.focus.ClearFocusTask' property 'focusFile' has @Input annotation used on property of type 'RegularFileProperty'.
    
    Reason: A property of type 'RegularFileProperty' annotated with @Input cannot determine how to interpret the file.
    
    Possible solutions:
      1. Annotate with @InputFile for regular files.
      2. Annotate with @InputFiles for collections of files.
      3. If you want to track the path, return File.absolutePath as a String and keep @Input.
    
    For more information, please refer to https://docs.gradle.org/8.5/userguide/validation_problems.html#incorrect_use_of_input_annotation in the Gradle documentation.
```

#### Build Stack
- AGP `8.1.1`
- Kotlin `1.9.20`
- Gradle `8.5`
- focus `0.5.1`