### PR TITLE
Fixes the clear focus task.

### DIFF
--- a/focus-gradle-plugin/api/focus-gradle-plugin.api
+++ b/focus-gradle-plugin/api/focus-gradle-plugin.api
@@ -2,7 +2,7 @@ public abstract class com/dropbox/focus/ClearFocusTask : org/gradle/api/DefaultT
 	public static final field Companion Lcom/dropbox/focus/ClearFocusTask$Companion;
 	public fun <init> ()V
 	public final fun clearFocus ()V
-	public abstract fun getFocusFile ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getFocusFilePath ()Lorg/gradle/api/provider/Property;
 }
 
 public final class com/dropbox/focus/ClearFocusTask$Companion {
@@ -30,6 +30,16 @@ public final class com/dropbox/focus/FocusPlugin : org/gradle/api/Plugin {
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V
 	public fun apply (Lorg/gradle/api/initialization/Settings;)V
+}
+
+public final class com/dropbox/focus/FocusPlugin$apply$1$1$1$1$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun execute (Ljava/lang/Object;)V
+}
+
+public final class com/dropbox/focus/FocusPlugin$apply$1$1$1$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun execute (Ljava/lang/Object;)V
 }
 
 public abstract class com/dropbox/focus/FocusSubExtension {

--- a/focus-gradle-plugin/build.gradle.kts
+++ b/focus-gradle-plugin/build.gradle.kts
@@ -28,12 +28,6 @@ tasks.withType<KotlinCompile>().configureEach {
     // Because Gradle's Kotlin handling is stupid, this falls out of date quickly
     apiVersion = "1.5"
     languageVersion = "1.5"
-
-    // We use class SAM conversions because lambdas compiled into invokedynamic are not
-    // Serializable, which causes accidental headaches with Gradle configuration caching. It's
-    // easier for us to just use the previous anonymous classes behavior
-    @Suppress("SuspiciousCollectionReassignment")
-    freeCompilerArgs += "-Xsam-conversion=class"
   }
 }
 

--- a/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/ClearFocusTask.kt
+++ b/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/ClearFocusTask.kt
@@ -3,25 +3,23 @@ package com.dropbox.focus
 import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 public abstract class ClearFocusTask : DefaultTask() {
 
-  @get:PathSensitive(PathSensitivity.RELATIVE)
-  @get:InputFile
-  public abstract val focusFile: RegularFileProperty
+  @get:Input
+  public abstract val focusFilePath: Property<String>
 
   @TaskAction
   public fun clearFocus() {
-    if (focusFile.isPresent) {
-      focusFile.asFile.get().delete()
+    val focusFile = File(focusFilePath.get())
+    if (focusFile.exists()) {
+      focusFile.delete()
     }
   }
 
@@ -30,7 +28,9 @@ public abstract class ClearFocusTask : DefaultTask() {
       focusFileName: Provider<String>
     ): ClearFocusTask.() -> Unit = {
       group = FOCUS_TASK_GROUP
-      this.focusFile.set(project.rootProject.layout.file(focusFileName.map { File(it) }))
+      this.focusFilePath.set(
+        project.rootProject.layout.file(focusFileName.map { File(it) }).map { it.asFile.absolutePath }
+      )
     }
   }
 }

--- a/focus-gradle-plugin/src/test/kotlin/com/dropbox/focus/FocusPluginTest.kt
+++ b/focus-gradle-plugin/src/test/kotlin/com/dropbox/focus/FocusPluginTest.kt
@@ -2,17 +2,22 @@ package com.dropbox.focus
 
 import com.google.common.truth.Truth.assertThat
 import java.io.File
+import java.time.temporal.Temporal
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class FocusPluginTest {
+  @get:Rule val buildDir = TemporaryFolder()
   private lateinit var gradleRunner: GradleRunner
 
   @Before
   fun setup() {
     gradleRunner = GradleRunner.create()
+      .withTestKitDir(buildDir.root)
       .withPluginClasspath()
   }
 
@@ -21,8 +26,16 @@ class FocusPluginTest {
     val fixtureRoot = File("src/test/projects/configuration-cache-compatible")
 
     gradleRunner
-      .withArguments("clearFocus", "--configuration-cache", "--stacktrace")
-      .runFixture(fixtureRoot) { build() }
+      .withArguments("--configuration-cache", "clearFocus")
+      .withProjectDir(fixtureRoot)
+      .build()
+
+    val result = gradleRunner
+      .withArguments("--configuration-cache", "clearFocus")
+      .withProjectDir(fixtureRoot)
+      .build()
+
+    assertThat(result.output).contains("Reusing configuration cache.")
   }
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.6.10"
 
 [libraries]
-junit = "junit:junit:4.12"
+junit = "junit:junit:4.13"
 truth = "com.google.truth:truth:1.1.3"
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -11,5 +11,5 @@ kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 dokka = { id = "org.jetbrains.dokka", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.18.0" }
-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.8.0" }
+binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.14.0" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes the clear focus task. Since the focus file itself may not exist, we need to make the input property the path instead of the file itself.

This does result in an API change, since the `clearFocusFile` task itself now has a different property. Since there's no change in the extension, however, I don't expect that to affect anyone, unless they're customizing Focus.