### PR TITLE
Fixes up workflow and publish config to automatically release.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Publish release
-        run: ./gradlew -p focus-gradle-plugin clean publishToMavenCentral --no-daemon --no-parallel --no-configuration-cache --stacktrace
+        run: ./gradlew -p focus-gradle-plugin clean publish --no-daemon --no-parallel --no-configuration-cache --stacktrace
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Publish release
-        run: ./gradlew -p focus-gradle-plugin clean publishAndReleaseToMavenCentral --no-daemon --no-parallel --no-configuration-cache --stacktrace
+        run: ./gradlew -p focus-gradle-plugin clean publishToMavenCentral --no-daemon --no-parallel --no-configuration-cache --stacktrace
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/focus-gradle-plugin/build.gradle.kts
+++ b/focus-gradle-plugin/build.gradle.kts
@@ -55,7 +55,7 @@ gradlePlugin {
 }
 
 mavenPublishing {
-  publishToMavenCentral(SonatypeHost.S01)
+  publishToMavenCentral(SonatypeHost.S01, true)
   signAllPublications()
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,6 @@ kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.28.0" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.29.0" }
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.14.0" }
 


### PR DESCRIPTION
This should fix up releases for snapshots and releases by leveraging [automatic releases](https://vanniktech.github.io/gradle-maven-publish-plugin/central/#automatic-release).