### PR TITLE
Fix for dependencyProject deprecation

### DIFF
--- a/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/CreateFocusSettingsTask.kt
+++ b/focus-gradle-plugin/src/main/kotlin/com/dropbox/focus/CreateFocusSettingsTask.kt
@@ -68,7 +68,7 @@ public abstract class CreateFocusSettingsTask : DefaultTask() {
         configuredProject.configurations.forEach { config ->
           config.dependencies
             .filterIsInstance<ProjectDependency>()
-            .map { it.dependencyProject }
+            .map { project.project(it.path) }
             .forEach(::addDependent)
         }
       }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionSha256Sum=bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fix for https://github.com/dropbox/focus/issues/54

This also update the project to Gradle 8.14.3 so that `it.path` works. 

Note: upgrade the project to Gradle v9 doesn't work. 